### PR TITLE
[Sample] Convert BoundLoggerBase's return type to Self

### DIFF
--- a/src/structlog/_base.py
+++ b/src/structlog/_base.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable, Mapping, Sequence
 
 from structlog.exceptions import DropEvent
 
-from .typing import BindableLogger, Context, Processor, WrappedLogger
+from .typing import BindableLogger, Context, Processor, Self, WrappedLogger
 
 
 class BoundLoggerBase:
@@ -62,7 +62,7 @@ class BoundLoggerBase:
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def bind(self, **new_values: Any) -> BoundLoggerBase:
+    def bind(self, **new_values: Any) -> Self:
         """
         Return a new logger with *new_values* added to the existing ones.
         """
@@ -72,7 +72,7 @@ class BoundLoggerBase:
             self._context.__class__(self._context, **new_values),
         )
 
-    def unbind(self, *keys: str) -> BoundLoggerBase:
+    def unbind(self, *keys: str) -> Self:
         """
         Return a new logger with *keys* removed from the context.
 
@@ -85,7 +85,7 @@ class BoundLoggerBase:
 
         return bl
 
-    def try_unbind(self, *keys: str) -> BoundLoggerBase:
+    def try_unbind(self, *keys: str) -> Self:
         """
         Like :meth:`unbind`, but best effort: missing keys are ignored.
 
@@ -97,7 +97,7 @@ class BoundLoggerBase:
 
         return bl
 
-    def new(self, **new_values: Any) -> BoundLoggerBase:
+    def new(self, **new_values: Any) -> Self:
         """
         Clear context and binds *new_values* using `bind`.
 


### PR DESCRIPTION
# Summary

## Problem

[`sample.py`](https://gist.github.com/pollenjp/1c4cbf9859d1317a2d6429a60a7227a7)

```py
import structlog

root_logger = structlog.get_logger()

root_logger = root_logger.bind(some="SOME")

if __name__ == "__main__":
  root_logger.info("hello", world="WORLD")
```

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/hynek/structlog/blob/main/.github/CONTRIBUTING.md) at least once; it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
-->

- [ ] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to our typing tests in [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      - The next version is the second number in the current release + 1. The first number represents the current year. So if the current version on PyPI is 23.1.0, the next version is gonna be 23.2.0. If the next version is the first in the new year, it'll be 24.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
